### PR TITLE
Patch for compatibility with jQuery 1.9

### DIFF
--- a/vendor/assets/javascripts/jquery.fancybox.js
+++ b/vendor/assets/javascripts/jquery.fancybox.js
@@ -7,7 +7,7 @@
  * Copyright (c) 2008 - 2010 Janis Skarnelis
  * That said, it is hardly a one-person project. Many people have submitted bugs, code, and offered their advice freely. Their support is greatly appreciated.
  *
- * Version: 1.3.4 (11/11/2010)
+ * Version: 1.3.4 (11/11/2010) patched for compatibility with jQuery 1.9.x (03/2013)
  * Requires: jQuery v1.3+
  *
  * Dual licensed under the MIT and GPL licenses:


### PR DESCRIPTION
See http://stackoverflow.com/questions/14344289/fancybox-doesnt-work-with-jquery-v1-9-0-f-browser-is-undefined-cannot-read for details.
