### PR TITLE
Added missing app folder

### DIFF
--- a/fancybox-rails.gemspec
+++ b/fancybox-rails.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
 
   s.summary     = "Use FancyBox with the Rails asset pipeline"
   s.description = "This gem provides jQuery FancyBox for your Rails application."
-  s.files       = Dir["{lib,vendor}/**/*"] + ["MIT-LICENSE", "Rakefile", "Gemfile", "README.md"]
+  s.files       = Dir["{app,lib,vendor}/**/*"] + ["MIT-LICENSE", "Rakefile", "Gemfile", "README.md"]
   s.version     = "0.3.0"
 
   s.add_dependency "railties", ">= 3.1.0"


### PR DESCRIPTION
Using 0.3.0 gem, the app folder is empty, thus all fancybox images are missing:

```
../gems/fancybox-rails-0.3.0 $ find  .
.
./Gemfile
./README.md
./MIT-LICENSE
./vendor
./vendor/assets
./vendor/assets/stylesheets
./vendor/assets/stylesheets/jquery.fancybox.css.erb
./vendor/assets/stylesheets/fancybox.css
./vendor/assets/javascripts
./vendor/assets/javascripts/jquery.browser.js
./vendor/assets/javascripts/jquery.fancybox.js
./vendor/assets/javascripts/fancybox.js
./Rakefile
./lib
./lib/fancybox-rails.rb
./lib/fancybox-rails
./lib/fancybox-rails/engine.rb
./lib/generators
./lib/generators/fancybox_rails_generator.rb
```